### PR TITLE
Add favicon

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width">
     <title>FAQ</title>
     <link rel="stylesheet" href="css/wgio.min.css">
+    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width">
     <title>W3C on GitHub</title>
     <link rel="stylesheet" href="css/wgio.min.css">
-    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width">
     <title>W3C on GitHub</title>
     <link rel="stylesheet" href="css/wgio.min.css">
+    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>

--- a/repo-management.html
+++ b/repo-management.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width">
     <title>Using GitHub for Spec Work</title>
     <link rel="stylesheet" href="css/wgio.min.css">
+    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>

--- a/specs.html
+++ b/specs.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width">
     <title>Using GitHub for Spec Work</title>
     <link rel="stylesheet" href="css/wgio.min.css">
+    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>

--- a/tmpl/top.html
+++ b/tmpl/top.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width">
     <title>{{title}}</title>
     <link rel="stylesheet" href="css/wgio.min.css">
+    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>

--- a/w3c.json.html
+++ b/w3c.json.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width">
     <title>The w3c.json file</title>
     <link rel="stylesheet" href="css/wgio.min.css">
+    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>


### PR DESCRIPTION
Link to the &ldquo;alternative&rdquo; *favicon* with a different hue that is now used in [labs.w3.org](https://labs.w3.org/), among other places.

Fix #6.