### PR TITLE
Add templates (with placeholders) for boilerplate files, and explain how to use them

### DIFF
--- a/specs.html
+++ b/specs.html
@@ -99,14 +99,22 @@ git push origin --delete master</code></pre>
     </li>
     <li>
       <p>
-        Finally, your <code>README.md</code> file should reflect the repository is used for spec
-        work. You can just copy an existing <code>README.md</code> if you can't recall the Markdown
-        specifics and amend it accordingly.
+        Finally, set up the boilerplate files.
       </p>
-      <pre><code>curl https://raw.github.com/tobie/specs-on-github/gh-pages/README.md &gt; README.md
-# Change the links inside of the readme file
-git add README.md
-git commit -m "Updated README to link to live spec."
+      <p>
+        Your <code>README.md</code> file should reflect the repository is used for spec work;
+	the rest of the files are probably a bit less important.
+        You can just copy
+	<a href="https://github.com/w3c/w3c.github.io/tree/master/templates">the templates provided</a>
+	and amend them accordingly.
+      </p>
+      <pre><code>curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/README.md
+curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/LICENSE.md
+curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/CONTRIBUTING.md
+curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/w3c.json
+# Edit the files (replace all the @@placeholders).
+git add README.md CONTRIBUTING.md LICENSE.md w3c.json
+git commit -m 'Add basic files: README, W3C JSON, etc.'
 git push origin</code></pre>
     </li>
     <li>

--- a/specs.src
+++ b/specs.src
@@ -79,14 +79,22 @@ git push origin --delete master</code></pre>
     </li>
     <li>
       <p>
-        Finally, your <code>README.md</code> file should reflect the repository is used for spec
-        work. You can just copy an existing <code>README.md</code> if you can't recall the Markdown
-        specifics and amend it accordingly.
+        Finally, set up the boilerplate files.
       </p>
-      <pre><code>curl https://raw.github.com/tobie/specs-on-github/gh-pages/README.md &gt; README.md
-# Change the links inside of the readme file
-git add README.md
-git commit -m "Updated README to link to live spec."
+      <p>
+        Your <code>README.md</code> file should reflect the repository is used for spec work;
+	the rest of the files are probably a bit less important.
+        You can just copy
+	<a href="https://github.com/w3c/w3c.github.io/tree/master/templates">the templates provided</a>
+	and amend them accordingly.
+      </p>
+      <pre><code>curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/README.md
+curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/LICENSE.md
+curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/CONTRIBUTING.md
+curl https://raw.githubusercontent.com/w3c/w3c.github.io/master/templates/w3c.json
+# Edit the files (replace all the @@placeholders).
+git add README.md CONTRIBUTING.md LICENSE.md w3c.json
+git commit -m 'Add basic files: README, W3C JSON, etc.'
 git push origin</code></pre>
     </li>
     <li>

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+@@guidelines-or-conventions
+
+Refer to [W3C on GitHub](https://w3c.github.io/) for more information on how to contribute.

--- a/templates/LICENSE.md
+++ b/templates/LICENSE.md
@@ -1,0 +1,5 @@
+# @@license-name
+
+Copyright © @@year [World Wide Web Consortium](http://www.w3.org/)
+
+@@verbatim-license

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,19 @@
+# @@name-of-spec
+
+@@one-sentence-description
+
+@@long-description
+
+## Authors
+
+@@info-about-group-and-editors
+
+## @@details
+
+@@whatever
+
+## Credits
+
+Copyright © @@year [World Wide Web Consortium](http://www.w3.org/)
+
+This project is licensed [under the terms of the @@chosen-license](LICENSE.md).

--- a/templates/w3c.json
+++ b/templates/w3c.json
@@ -1,0 +1,6 @@
+{
+    "group":     "@@group-ID",
+    "contacts":  ["@@editor-1", "@@editor-2", "@@some-maintainer"],
+    "shortName": "@@shortname",
+    "policy":    "@@open-or-restricted"
+}


### PR DESCRIPTION
Fix w3c/using-github#9.