### PR TITLE
FAQ: avoid ambiguity about *who* creates new GH repos

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -69,8 +69,9 @@
           contributing to the document, and give that team push and pull access.
         </li>
         <li>
-          Create a new repository for each document (each deliverable, it can of course contain
-          multiple resources). Add each such repository to the GitHub team so that the contributors
+          W3C staff (or Team Contacts of the group) create a new repository for each document
+          (each deliverable, it can of course contain multiple resources).
+          Add each such repository to the GitHub team so that the contributors
           all have push access. Other people can suggest changes by submitting pull requests (in
           fact, editors can do that too to enable reviewing before commits, if desired), but not
           every contributor will be given direct commit access.
@@ -78,7 +79,7 @@
       </ol>
     </section>
     <section>
-      <h3>Detailed steps for staff contacts to create a repo</h3>
+      <h3>Detailed steps <em>for staff contacts</em> to create a repo</h3>
       <p>
         <strong>
           The preferred way to create new repositories is by using

--- a/faq.src
+++ b/faq.src
@@ -49,8 +49,9 @@
           contributing to the document, and give that team push and pull access.
         </li>
         <li>
-          Create a new repository for each document (each deliverable, it can of course contain
-          multiple resources). Add each such repository to the GitHub team so that the contributors
+          W3C staff (or Team Contacts of the group) create a new repository for each document
+          (each deliverable, it can of course contain multiple resources).
+          Add each such repository to the GitHub team so that the contributors
           all have push access. Other people can suggest changes by submitting pull requests (in
           fact, editors can do that too to enable reviewing before commits, if desired), but not
           every contributor will be given direct commit access.
@@ -58,7 +59,7 @@
       </ol>
     </section>
     <section>
-      <h3>Detailed steps for staff contacts to create a repo</h3>
+      <h3>Detailed steps <em>for staff contacts</em> to create a repo</h3>
       <p>
         <strong>
           The preferred way to create new repositories is by using


### PR DESCRIPTION
A user reported being confused about whether they should create a new GH repo for their spec and then notify W3C staff, or ask their team contact to do so instead (cf sysreq ticket no. 11662).

This tries to clarify that.