### PR TITLE
Don't encourage changes license/contributing

### DIFF
--- a/specs.html
+++ b/specs.html
@@ -79,7 +79,7 @@ git commit -m "Add empty doc."</code></pre>
     </li>
     <li>
       <p>
-        Setup your <a href="spec-labels.html">favorite labels</a>
+        Setup your <a href="issue-metadata.html.">favorite labels</a>.
       </p>
     </li>
     <li>

--- a/specs.html
+++ b/specs.html
@@ -78,15 +78,6 @@ git commit -m "Add empty doc."</code></pre>
       </p>
     </li>
     <li>
-      <p>Edit the boilerplate files.</p>
-      <p>
-        In particular, you may want to replace the license, picking a different pair of documents
-        (<code>LICENSE.md</code> and <code>CONTRIBUTING.md</code>) from
-      	<a href="https://github.com/w3c/licenses"><code>github.com/w3c/licenses</code></a>.
-        Review the files <code>README.md</code> and <code>w3c.json</code>, too.
-      </p>
-    </li>
-    <li>
       <p>
         Setup your <a href="spec-labels.html">favorite labels</a>
       </p>


### PR DESCRIPTION
These should be standard across every repo - we shouldn't have people fiddling with them. Not without good reason.