### PR TITLE
moved content around, added using github page

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -34,49 +34,9 @@
   <section>
     <h2>Getting Started</h2>
     <section>
-      <h3>Informal drafts in your personal account</h3>
       <p>
-        Getting started individually obviously doesn't require any approval process. Create an
-        informal draft (using ReSpec makes it easy) by starting a new repository with your personal
-        GitHub account. We strongly recommend one repository per document, unless you really
-        know why you're doing it differently.
+	      See the <a href="usinggithub.html">Using Github</a> page for how to get started. 
       </p>
-      <p>
-        You can just publish HTML as you normally would simply by setting up
-        <a href="https://github.com/blog/2228-simpler-github-pages-publishing">GitHub Pages</a>
-        to use the default branch, <code>master</code>.
-      </p>
-    </section>
-    <section>
-      <h3>Hosting a repository within the <code>w3c</code> organisation</h3>
-      <p>
-        W3C projects include W3C staff selected projects as well as W3C Working (Interest) Group projects.
-        It is possible that we decide to assess other group's requests to host a given repository.
-        In any case, a prerequisite would be identifying the owner(s) either by name or by e-mail address.
-        Refer to <a href="https://www.w3.org/2016/04/cg-support/#what">the Guidebook for Community Groups</a>
-        for more information.
-      </p>
-      <ol>
-        <li>
-          Your Team Contact should become (if they're not already) a part of the
-          <a href="https://github.com/organizations/w3c/settings/owners">Owners Team</a> of the W3C
-          organisation. (Ask any of the current owners directly, or ask on &amp;sysreq. This is only
-          for W3C Staff.)
-        </li>
-        <li>
-          If there is no GitHub team roughly matching the group that will be pushing to that
-          repository, the Team Contact should create a new team for the editors who will be
-          contributing to the document, and give that team push and pull access.
-        </li>
-        <li>
-          W3C staff (or Team Contacts of the group) create a new repository for each document
-          (each deliverable, it can of course contain multiple resources).
-          Add each such repository to the GitHub team so that the contributors
-          all have push access. Other people can suggest changes by submitting pull requests (in
-          fact, editors can do that too to enable reviewing before commits, if desired), but not
-          every contributor will be given direct commit access.
-        </li>
-      </ol>
     </section>
     <section>
       <h3>Detailed steps <em>for staff contacts</em> to create a repo</h3>
@@ -131,6 +91,19 @@
       </p>
     </section>
   </section>
+  <section>
+    <h2>Global Access</h2>
+    <section>
+      <p>
+         Github is currently not blocked in any country, but this sometimes changes. See <a href="https://en.wikipedia.org/wiki/Censorship_of_GitHub">Censorship of Github</a> on Wikipedia for up to date details on Github blocks. If you reside in a country which is blocking Wikipedia please ask your group chair to provide you with information on Github blocks.
+      </p>
+      <p>
+	      Not having access to Github will make work difficult but not impossible. Chairs should be prepared to share Github held repositories with their members in countries which do not have access to Github at any one period. The chair can clone the repo, and send this via any method with a member in a blocked country. That member will need to have git installed on their local system, then they can branch, edit and commit to that repo and send this back to the group for merging with the main Github-held repository. This is not ideal, but is an adequate work-around. For other possible methods please consult your group chair. 
+      </p>    
+      <p>
+	      Some corporate firewalls may block Github. In these instances, members should clone or pull Github repos when they are not on their corporate firewalls, branch and edit, and then pull request once they are off their corporate network again. Any W3C member organisation should consider removing Github from their firewall settings.  
+      </p>
+    </section>
   <section>
     <h2>Policy</h2>
     <section>

--- a/index.html
+++ b/index.html
@@ -24,24 +24,25 @@
 
 <main>
   <p>
-    The purpose of this page is to progressively list the resources useful when working on
-    W3C projects using GitHub.
+    Most W3C groups use Github to manage their work and develop specifications. This site contains guidelines and a list of resources for using GitHub with W3C projects.
     The following links should help you find your way.
     Refer to the <a href="faq.html">FAQ</a> for details about the breadth and scope of W3C projects.
   </p>
   <dl>
+    <dt><a href="usinggithub.html">Why Use Github?</a></dt>
+    <dd>
+      W3C Groups use Github for spec development and easy group and task management. Find out <a href="usinggithub.html">here</a> why groups use Github, and understand the general W3C group <a href="usinggithub.html#githubflow">Github Flow</a>.
+    </dd>
     <dt><a href="https://github.com/w3c/">Repositories</a></dt>
     <dd>
-      If you are looking for a specific project that we maintain on GitHub, the best is to go
+      If you are looking for a specific project that W3C maintain on GitHub (including specifications and group work), the best is to go
       straight to the list of repositories, which is searchable.
     </dd>
     <dt><a href="https://help.github.com/">GitHub Help</a></dt>
     <dd>
-      Most of the issues people have using GitHub are in fact due to <code>git</code>. General
-      <code>git</code> and GitHub questions will not be addressed here.
+      Github's functionality is based on <code>git</code> version control. Most of the issues people have using GitHub are in fact related to <code>git</code>. General <code>git</code> and GitHub questions will not be addressed on this site.
       GitHub's own help site linked above is a very helpful resource.
-      You can also usually just cut and paste from
-      <a href="http://stackoverflow.com/questions/tagged/git">Stack Overflow's git questions</a>.
+      <a href="http://stackoverflow.com/questions/tagged/git">Stack Overflow's git questions</a> and <a href="https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf">Github's git Cheat Sheet</a> are also helpful.
       Eric Eggert conducted a <a href="http://w3c.github.io/wai-gh-training-2015-06-29/">training
       session about Git and GitHub (1h40&prime; video + slides)</a>.
     </dd>

--- a/usinggithub.html
+++ b/usinggithub.html
@@ -1,0 +1,118 @@
+<!--
+  CAUTION: This is auto-generated; edit the .src instead.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>FAQ</title>
+    <link rel="stylesheet" href="css/wgio.min.css">
+    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
+  </head>
+  <body>
+    <header>
+      <h1>Using Github</h1>
+    </header>
+<nav>
+  <a href="index.html">Home</a>
+  •
+  <a href="https://github.com/w3c/">Repositories</a>
+  •
+  <a href="https://help.github.com/">GitHub Help</a>
+</nav>
+
+<main>
+    <section>
+	  <h2>Why Use Github?</h2>
+	  <p>
+	    W3C groups have been moving to use <a href="https://github.com/">GitHub</a> for reasons including:
+	  </p>
+	    <ul>
+		    <li><strong>Version Control:</strong> Github uses <a href="https://git-scm.com/">Git</a> for version control. This means group members, editors, chairs and the public can easily track and find changes to specifications and other work, refer and rollback to these edits when necessary</li>
+		    <li><strong>User Experience:</strong> Github provides a clean UI for version control and issue management, making it easy for members to use and follow</li>
+		    <li><strong >Issues:</strong> Every Github repository has an issues section. Members can open issues, discuss them, assign them to individuals and label issues for projects and topics. <a href="https://github.com/w3c/payment-request/issues">PaymentRequest</a> gives a good example of well managed Github issues.</li>
+		    <li><strong>Notifications:</strong> Github can send notifications when issues have been discussed, pull requests have been accepted and other general actions have been completed. Guidelines on how to change your notifcation settings can be found <a href="https://help.github.com/articles/choosing-the-types-of-notifications-you-receive/">here</a>.</li>
+		    <li><strong>Integration with W3C Systems:</strong> Some groups and members like to receive their Github notifications via W3C mailing lists. See guidelines on how to do this on the <a href="faq.html">faq</a> page.</li>	    
+		    <li><strong>Global Access:</strong> Github is available around the world and in 日本語 (Japanese), Français (French), Српски (Serbian), Deutsch (German), Svenska (Swedish), Hrvatski (Croatian), Polski (Polish) and Nederlands (Dutch). Github is currently is not blocked in any country, guidelines for country-based and corporate blocks can be found in the <a href="faq.html">faq</a> page. 
+		    <li><strong>Improved Group Management:</strong> being a chair, team contact and W3C member is hard! Github makes management of our W3C tasks easier by grouping our pull requests and issues, sending us notifications, having a clear UI and managing versions.</li>
+	    </ul> 
+	
+	    <p>
+		    If you have any suggestions or issues related to the use of Github please raise them in the <a href="https://github.com/w3c/w3c.github.io/issues">issues</a> section of this repository.
+	    </p>    
+	    
+	    <p>
+			Below are some guidelines on getting started and using Github in your W3C group.
+		</p>
+    </section>
+	<section>
+		<h2>Getting Started</h2>
+		<section>
+		  	<p>
+		   		Working on Github requires a Github account, set this up by going to <a href="https://github.com/">github.com</a>. An email is required to register, but if you wish you do not need to share any other personal information with Github. Once registered, you should be able to make new repositories which are attached to your account. 
+		  	</p>
+		  	<h3>Create an informal draft using your personal account</h3>
+		      <p>
+		        Getting started individually obviously doesn't require any approval process, so there's no need for you to check with chairs or members before getting started. Start a new repo using your account, and create an informal draft. We recommend using <a href="https://github.com/w3c/respec">ReSpec</a>, Respec is a tool which can help make W3C drafts easily. We strongly recommend one repository per document, unless you really know why you're doing it differently.
+		      </p>
+		      <p>
+		        You can just publish HTML as you normally would simply by setting up
+		        <a href="https://github.com/blog/2228-simpler-github-pages-publishing">GitHub Pages</a>
+		        to use the default branch, <code>master</code>. Github Pages should allow you to see the draft document hosted via Github. 
+		      </p>
+		      <p>
+			    Let the group know you have created an informal draft and share the link to your new repo under your account. The group can then discuss whether to bring this into the group as an official First Public Working Draft. 
+		      </p>
+		    </section>
+		    <section>
+		      <h3>Host the repository within the <code>w3c</code> organisation</h3>
+		      <p>
+			    The <a href="https://github.com/w3c">W3C</a> main Github oragnisation account will hold all the repos for W3C specifications and W3C Team projects. Once a group has accepted a document as a First Public Working Draft the document may become eligible for being moved to the main W3C account. Before this happens, make sure the draft owner(s) are identifiable by either by name or by e-mail address. Community Groups should refer to <a href="https://www.w3.org/2016/04/cg-support/#what">the Guidebook for Community Groups</a> for more information relating to their documents.
+		      </p>
+		      <ol>
+		        <li>
+		          Your Team Contact should be a part of the
+		          <a href="https://github.com/organizations/w3c/settings/owners">Owners Team</a> of the W3C
+		          organisation. (W3C Staff: ask any of the current owners directly for access, or ask on &amp;sysreq.)
+		        </li>
+		        <li>
+		          If there is no GitHub team roughly matching the group that will be pushing to that
+		          repository, the Team Contact should create a new team for the editors who will be
+		          contributing to the document, and give that team push and pull access.
+		        </li>
+		        <li>
+		          W3C staff (or Team Contacts of the group) create a new repository for each document
+		          (each deliverable, it can of course contain multiple resources).
+		          Add each such repository to the GitHub team so that the contributors
+		          all have push access. Other people can suggest changes by submitting pull requests (in
+		          fact, editors can do that too to enable reviewing before commits, if desired), but not
+		          every contributor will be given direct commit access.
+		        </li>
+		      </ol>		  
+		      <p>
+			      Staff can see the <a href="faq.html">faq</a> page for detailed steps for staff contacts on creating a repo.
+		      </p>
+		</section>
+	</section>
+	<section>
+		<h2>Workflow</h2>
+	  	<p>
+	   		@todo. Link to <a href="workflow.html">workflow</a> and <a href="repo-management.html">Contributor Management</a>.
+	  	</p>
+	</section>
+	<section>
+		<h2>Using Issues</h2>
+	  	<p>
+	   		@todo. Link to <a href="issue-metadata.html">labels</a>.
+	  	</p>
+	</section>
+</main>
+    <footer>
+      <address><a href="https://github.com/w3c/w3c.github.io/">We are on GitHub</a></address>
+      <p>
+        <a href="https://www.w3.org/"><img src="img/w3c.svg" width="65" height="45" alt="W3C Logo"></a>
+      </p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
Moved a bunch of content around to make this easier for the viewer. These are the changes:

- Added a "usinggithub.html" page as an intro to how and why W3C use github for spec work. 
- Moved "Getting Started" from the faq to the new "usinggithub.html" page
- W3C Staff instructions remain in faq - the idea is that staff will get to grips with things faster, and this guide should be more targeted to members and editors
- re-ordered the index.html page, to put the "usinggithub" page at the top with the title "Why Use Github?"
- re-wrote some content to make it easier to read
- added globalisation and block information in faq, this should be checked by legal.

Shout if there are any issues!