### PR TITLE
GH best practices: mention all notification channels

### DIFF
--- a/best-practices.html
+++ b/best-practices.html
@@ -197,7 +197,10 @@ logs/</pre>
                         <li>On the <em>Dependency Graph</em> page; ie <code>https://github.com/w3c/&lt;REPO&gt;/network/dependencies</code></li>
                     </ul>
                     <p>Finally, make sure you are receiving <em>notifications</em> about vulnerability alerts:
-                        <a href="https://github.com/settings/notifications"><code>github.com/settings/notifications</code></a> (bottom of the page).</p>
+                        <a href="https://github.com/settings/notifications"><code>github.com/settings/notifications</code></a> (bottom of the page).
+                        You can tweak the different <em>channels</em> (UI, web, e-mail); we recommend you enable e-mail notifications at least, if you don't
+                        have a habit of visiting the pages of your maintained repos very often&nbsp;&mdash;&nbsp;otherwise you risk missing vulnerability
+                        alerts.</p>
                 </section>
                 <section id="ci">
                     <h3>Set up <abbr title="continuous integration">CI</abbr> <a href="#ci">&#x1F517;</a></h3>


### PR DESCRIPTION
GH allows now more granularity for notifications, and more channels to deliver them. Mention that explicitly for repo maintainers and encourage them to enable channels that are convenient for them.