### PR TITLE
Add type and accepted values information

### DIFF
--- a/specs.html
+++ b/specs.html
@@ -41,13 +41,13 @@
       <p>
         Clone the repository locally.
       </p>
-      <pre><code>git clone https://github.com/tobie/specs-on-github.git</code></pre>
+      <pre>git clone https://github.com/tobie/specs-on-github.git</pre>
     </li>
     <li>
       <p>
         Navigate to the repo.
       </p>
-      <pre><code>cd specs-on-github</code></pre>
+      <pre>cd specs-on-github</pre>
     </li>
     <li>
       <p>
@@ -55,20 +55,20 @@
         href="https://github.com/darobin/respec/">ReSpec</a>, so I simply curl the content of the
         default template into an <code>index.html</code> page at the root of my repository.
       </p>
-      <pre><code>curl https://www.w3.org/respec/examples/template.html &gt; index.html</code></pre>
+      <pre>curl https://www.w3.org/respec/examples/template.html &gt; index.html</pre>
     </li>
     <li>
       <p>
         We can then add it to the repository.
       </p>
-      <pre><code>git add index.html
-git commit -m "Add empty doc."</code></pre>
+      <pre>git add index.html
+git commit -m "Add empty doc."</pre>
     </li>
     <li>
       <p>
         Lets now push these changes back to our GitHub account.
       </p>
-      <pre><code>git push origin master</code></pre>
+      <pre>git push origin master</pre>
       <p>
         The first time you push changes it can take a little while for the code
         to be published to your subdomain, so be patient. But it'll be ready soon enough.

--- a/w3c.json.html
+++ b/w3c.json.html
@@ -33,7 +33,7 @@
   <pre>{
     "group":     40318
 ,   "contacts":  ["darobin", "sideshowbarker"]
-,   "repo-type": ["rec-track"]
+,   "repo-type": "rec-track"
 }</pre>
   <p>
     The fields that are understood at this point are:
@@ -66,7 +66,7 @@
 
     <dt id="repo-type"><code>repo-type</code></dt>
     <dd>
-    String to identify the type and purpose of the repository.
+    String to identify the type and purpose of the repository, or an array of such strings if the repository holds more than one type of content.
     The possible values for this field are:<br/><br/>
     <dl>
       <dt>rec-track</dt>
@@ -85,6 +85,9 @@
 
       <dt>homepage</dt>
       <dd>Groups' homepages</dd>
+
+      <dt>article</dt>
+      <dd>Non-spec documents</dd>
 
       <dt>tool</dt>
       <dd>Development of tools</dd>

--- a/w3c.json.html
+++ b/w3c.json.html
@@ -69,7 +69,7 @@
     String to identify the type and purpose of the repository, or an array of such strings if the repository holds more than one type of content.
     The possible values for this field are:<br/><br/>
     <dl>
-      <dt class='value'>rec-track</dt>
+      <dt class="value">rec-track</dt>
       <dd>W3C Recommendation Track Documents including First Public
       Working Draft, Working Draft, Candidate Recommendation, Proposed
       Recommendation and W3C Recommendation</dd>

--- a/w3c.json.html
+++ b/w3c.json.html
@@ -39,7 +39,7 @@
     The fields that are understood at this point are:
   </p>
   <dl>
-    <dt id="group"><code>group</code></dt>
+    <dt id="group" date-type="number|array&lt;number>"><code>group</code></dt>
     <dd>
       The numeric ID of the group in charge of this repo. While it is
       inconvenient for humans to find such IDs they are the best thing
@@ -55,7 +55,7 @@
       <pre>"group": [35422, 83907]</pre>
     </dd>
 
-    <dt id="contacts"><code>contacts</code></dt>
+    <dt id="contacts" date-type="array&lt;string>"><code>contacts</code></dt>
     <dd>
       An array of people who are considered points of contact for the
       repository for administrative requests. They aren't necessarily
@@ -64,47 +64,47 @@
       For integration purposes, please use your <em>GitHub</em> ID.
     </dd>
 
-    <dt id="repo-type"><code>repo-type</code></dt>
+    <dt id="repo-type" data-type="string"><code>repo-type</code></dt>
     <dd>
     String to identify the type and purpose of the repository, or an array of such strings if the repository holds more than one type of content.
     The possible values for this field are:<br/><br/>
     <dl>
-      <dt>rec-track</dt>
+      <dt class='value'>rec-track</dt>
       <dd>W3C Recommendation Track Documents including First Public
       Working Draft, Working Draft, Candidate Recommendation, Proposed
       Recommendation and W3C Recommendation</dd>
 
-      <dt>note</dt>
+      <dt class='value'>note</dt>
       <dd>W3C Group Note including Working Group Note and Interest Group Note</dd>
 
-      <dt>cg-report</dt>
+      <dt class='value'>cg-report</dt>
       <dd>W3C Community Group Report</dd>
 
-      <dt>process</dt>
+      <dt class='value'>process</dt>
       <dd>Discussion on the W3C Process document</dd>
 
-      <dt>homepage</dt>
+      <dt class='value'>homepage</dt>
       <dd>Groups' homepages</dd>
 
       <dt>article</dt>
       <dd>Non-spec documents</dd>
 
-      <dt>tool</dt>
+      <dt class='value'>tool</dt>
       <dd>Development of tools</dd>
 
-      <dt>project</dt>
+      <dt class='value'>project</dt>
       <dd>Group-independent projects</dd>
 
-      <dt>others</dt>
+      <dt class='value'>others</dt>
       <dd>Other purposes</dd>
     </dl>
     </dd>
 
-    <dt id="policy"><code>policy</code></dt>
+    <dt id="policy" data-type="string"><code>policy</code></dt>
     <dd>
-      This is essentially a W3C-internal flag. If set to <code>open</code>, any W3C Team member
+      This is essentially a W3C-internal flag. If set to <code class='value'>open</code>, any W3C Team member
       should feel empowered to help with the management of this given repository. This can be
-      set to <code>restricted</code> to indicate that for whatever reason, it is preferable to
+      set to <code class='value'>restricted</code> to indicate that for whatever reason, it is preferable to
       let the repository be handled only by team contacts directly associated with it. The
       default value is <code>open</code>.
     </dd>

--- a/w3c.json.html
+++ b/w3c.json.html
@@ -74,37 +74,37 @@
       Working Draft, Working Draft, Candidate Recommendation, Proposed
       Recommendation and W3C Recommendation</dd>
 
-      <dt class='value'>note</dt>
+      <dt class="value">note</dt>
       <dd>W3C Group Note including Working Group Note and Interest Group Note</dd>
 
-      <dt class='value'>cg-report</dt>
+      <dt class="value">cg-report</dt>
       <dd>W3C Community Group Report</dd>
 
-      <dt class='value'>process</dt>
+      <dt class="value">process</dt>
       <dd>Discussion on the W3C Process document</dd>
 
-      <dt class='value'>homepage</dt>
+      <dt class="value">homepage</dt>
       <dd>Groups' homepages</dd>
 
       <dt>article</dt>
       <dd>Non-spec documents</dd>
 
-      <dt class='value'>tool</dt>
+      <dt class="value">tool</dt>
       <dd>Development of tools</dd>
 
-      <dt class='value'>project</dt>
+      <dt class="value">project</dt>
       <dd>Group-independent projects</dd>
 
-      <dt class='value'>others</dt>
+      <dt class="value">others</dt>
       <dd>Other purposes</dd>
     </dl>
     </dd>
 
     <dt id="policy" data-type="string"><code>policy</code></dt>
     <dd>
-      This is essentially a W3C-internal flag. If set to <code class='value'>open</code>, any W3C Team member
+      This is essentially a W3C-internal flag. If set to <code class="value">open</code>, any W3C Team member
       should feel empowered to help with the management of this given repository. This can be
-      set to <code class='value'>restricted</code> to indicate that for whatever reason, it is preferable to
+      set to <code class="value">restricted</code> to indicate that for whatever reason, it is preferable to
       let the repository be handled only by team contacts directly associated with it. The
       default value is <code>open</code>.
     </dd>

--- a/w3c.json.html
+++ b/w3c.json.html
@@ -39,7 +39,7 @@
     The fields that are understood at this point are:
   </p>
   <dl>
-    <dt id="group" date-type="number|array&lt;number>"><code>group</code></dt>
+    <dt id="group" data-type="number|array&lt;number>"><code>group</code></dt>
     <dd>
       The numeric ID of the group in charge of this repo. While it is
       inconvenient for humans to find such IDs they are the best thing
@@ -55,7 +55,7 @@
       <pre>"group": [35422, 83907]</pre>
     </dd>
 
-    <dt id="contacts" date-type="array&lt;string>"><code>contacts</code></dt>
+    <dt id="contacts" data-type="array&lt;string>"><code>contacts</code></dt>
     <dd>
       An array of people who are considered points of contact for the
       repository for administrative requests. They aren't necessarily
@@ -64,7 +64,7 @@
       For integration purposes, please use your <em>GitHub</em> ID.
     </dd>
 
-    <dt id="repo-type" data-type="string"><code>repo-type</code></dt>
+    <dt id="repo-type" data-type="string|array&lt;string>"><code>repo-type</code></dt>
     <dd>
     String to identify the type and purpose of the repository, or an array of such strings if the repository holds more than one type of content.
     The possible values for this field are:<br/><br/>

--- a/w3c.json.html
+++ b/w3c.json.html
@@ -30,13 +30,11 @@
   <p>
     Here is an example:
   </p>
-  <pre>
-    {
-        "group":      40318
-    ,   "contacts":   ["darobin", "sideshowbarker"]
-    ,   "repo-type":  ["rec-track"]
-    }
-  </pre>
+  <pre>{
+    "group":     40318
+,   "contacts":  ["darobin", "sideshowbarker"]
+,   "repo-type": ["rec-track"]
+}</pre>
   <p>
     The fields that are understood at this point are:
   </p>
@@ -48,11 +46,13 @@
       we have to programmatically create links between repositories
       and a whole lot of other data we have that are using this type
       of identifier.
-      <br/><br/>
+      <br />
+      <br />
       <strong>Note:</strong> If the group is actually a joint task
       force of more than group, please specify all the IDs of the
-      groups consist of the task force as an array, e.g.:<br/>
-      &nbsp;&nbsp;&nbsp;&nbsp;<pre>"group": [35422, 83907]</pre>
+      groups consist of the task force as an array, e.g.:
+      <br />
+      <pre>"group": [35422, 83907]</pre>
     </dd>
 
     <dt id="contacts"><code>contacts</code></dt>

--- a/workflow.html
+++ b/workflow.html
@@ -31,19 +31,19 @@
       <p>
         Navigate to the repo.
       </p>
-      <pre><code>cd specs-on-github</code></pre>
+      <pre>cd specs-on-github</pre>
     </li>
     <li>
       <p>
         Checkout the main branch of your repository (in general, this is the <code>master</code> branch).
       </p>
-      <pre><code>git checkout master</code></pre>
+      <pre>git checkout master</pre>
     </li>
     <li>
       <p>
         Make sure the main branch is up-to-date with upstream.
       </p>
-      <pre><code>git pull</code></pre>
+      <pre>git pull</pre>
       <p>
         If you forked the repository on GitHub, you may need to indicate the upstream repository more explicitly.
       </p>
@@ -53,7 +53,7 @@
         Create a new branch for your upcoming pull request (one branch per pull request). Please make branch names
         informative - by including the issue or bug number for example.
       </p>
-      <pre><code>git checkout -b my-wonderful-edits-for-87</code></pre>
+      <pre>git checkout -b my-wonderful-edits-for-87</pre>
     </li>
     <li>
       <p>
@@ -68,27 +68,28 @@
         be part of the commit. This allows you to make  multiple edits at once and split them into different more
         meaningful/easy-to-review commits.
       </p>
-      <pre><code>git add -p</code></pre>
+      <pre>git add -p</pre>
     </li>
     <li>
       <p>
         Commit your staged edits. If you're fixing an issue, reference it in the commit e.g. <code>fix #87</code>
         (if you write close or fix, it will automatically close the issue once the commit is added to the main branch).
       </p>
-      <pre><code>git commit -m "&lt;purpose of your edits> (fix #number)"</code></pre>
-      <p><code>git commit --amend</code> allows you to replace the last commit with a new one, if you feel the need to change it.</p>
+      <pre>git commit -m "&lt;purpose of your edits&gt; (fix #number)"</pre>
+      <p>This command allows you to replace the last commit with a new one, if you feel the need to change it:</p>
+      <pre>git commit --amend</pre>
     </li>
     <li>
       <p>
         Once all your commits are done, push your branch upstream.
       </p>
-      <pre><code> git push --set-upstream origin my-wonderful-edits-for-87</code></pre>
+      <pre>git push --set-upstream origin my-wonderful-edits-for-87</pre>
     </li>
     <li>
       <p>
         Using your favorite browser, navigate to the repo on GitHub, e.g.
       </p>
-      <pre><code>https://github.com/tobie/specs-on-github/</code></pre>
+      <pre>https://github.com/tobie/specs-on-github/</pre>
     </li>
     <li>
       <p>


### PR DESCRIPTION
Those annotations are intended to be used by validate-repo in the future. It will avoid having to change validate-repo when a new value is added for example for repo-type.

