### PR TITLE
Remove incorrect favicon link

### DIFF
--- a/w3c.json.html
+++ b/w3c.json.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width">
     <title>The w3c.json file</title>
     <link rel="stylesheet" href="css/wgio.css">
-    <link rel="icon" type="image/x-icon" href="//labs.w3.org/favicon.ico">
   </head>
   <body>
     <header>


### PR DESCRIPTION
The favicon redirects to a web page that is not a favicon. The redirect destination is on HTTP leading to Mixed Content errors on https://w3c.github.io/w3c.json.html