### PR TITLE
Fix Speech API JavaScript redirects

### DIFF
--- a/speech-api/speechapi.html
+++ b/speech-api/speechapi.html
@@ -3,7 +3,7 @@
 <meta charset="utf-8">
 <title>Moved…</title>
 </head>
-<body onload='function() { location.href = "https://w3c.github.io/speech-api/" + location.hash; }'>
+<body onload='(function() { location.href = "https://wicg.github.io/speech-api/" + location.hash; })()'>
 <p>Moved to
 <a href="https://wicg.github.io/speech-api/">https://wicg.github.io/speech-api/</a>
 </body>

--- a/speech-api/webspeechapi.html
+++ b/speech-api/webspeechapi.html
@@ -3,7 +3,7 @@
 <meta charset="utf-8">
 <title>Moved…</title>
 </head>
-<body onload='function() { location.href = "https://w3c.github.io/speech-api/" + location.hash; }'>
+<body onload='(function() { location.href = "https://wicg.github.io/speech-api/" + location.hash; })()'>
 <p>Moved to
 <a href="https://wicg.github.io/speech-api/">https://wicg.github.io/speech-api/</a>
 </body>


### PR DESCRIPTION
This applies the same fix as in https://github.com/w3c/w3c.github.io/commit/41ddcca148ed206d02ba285dbd865494928b1ad4.