### PR TITLE
Add redirects for https://w3c.github.io/webappsec-feature-policy/

### DIFF
--- a/webappsec-feature-policy/document-policy.html
+++ b/webappsec-feature-policy/document-policy.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved…</title>
+</head>
+<body onload='(function() { location.href = "https://w3c.github.io/webappsec-permissions-policy/document-policy.html" + location.hash; })()'>
+<p>Moved to
+<a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html">https://w3c.github.io/webappsec-permissions-policy/document-policy.html</a>
+</body>

--- a/webappsec-feature-policy/index.html
+++ b/webappsec-feature-policy/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<head>
+<meta charset="utf-8">
+<title>Moved…</title>
+</head>
+<body onload='(function() { location.href = "https://w3c.github.io/webappsec-permissions-policy/" + location.hash; })()'>
+<p>Moved to
+<a href="https://w3c.github.io/webappsec-permissions-policy/">https://w3c.github.io/webappsec-permissions-policy/</a>
+</body>


### PR DESCRIPTION
It is 404 following a repo rename.