### PR TITLE
setting expectation that not all the work is on GH

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
 
 <main>
   <p>
+    Many W3C work group conduct their work in Github, but not all. Please, explore our repos, watch, star, contribute.
+  </p>
+  <p>
     The purpose of this page is to progressively list the resources useful when working on
     W3C projects using GitHub.
     The following links should help you find your way.


### PR DESCRIPTION
If we end up including a pointer to our GH from the W3C website footers, at least, we should set the right expectation and clarify that not every group use it.
