### PR TITLE
Renamed PING to Privacy

### DIFF
--- a/hr-labels.json
+++ b/hr-labels.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "privacy-tracker",
-    "groupname": "PING",
+    "groupname": "Privacy",
     "longdesc": "The Privacy Group (PING) may add this label to indicate that they are following a discussion. Other WGs can also add the label to any issue to automatically bring the discussion to the attention of the PING Group. Issues with this label don't need to be resolved to the satisfaction of the PING Group before a transition.",
     "description": "Group bringing to attention of Privacy, or tracked by the Privacy Group but not needing response.",
     "color": "d4af37",
@@ -31,7 +31,7 @@
   },
   {
     "name": "privacy-needs-resolution",
-    "groupname": "PING",
+    "groupname": "Privacy",
     "longdesc": "The Privacy Group (PING) has raised, or is following this issue, and expects it to be resolved to their satisfaction before a transition. This label is added/applied only by the PING Group, and should only be removed by them. It may replace an privacy-tracker label.",
     "description": "Issue the Privacy Group has raised and looks for a response on.",
     "color": "d4af37",


### PR DESCRIPTION
@xfq would like "Privacy" instead of "Ping" in documents like:
   https://www.w3.org/PM/horizontal/review.html?shortname=screen-wake-lock

cc @samuelweiler 