### PR TITLE
Fix typo: pluralise "many W3C work groups"

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
 <main>
   <p>
-    Many W3C work group conduct their work in Github, but not all. Please, explore our repos, watch, star, contribute.
+    Many W3C work groups conduct their work in Github, but not all. Please, explore our repos, watch, star, contribute.
   </p>
   <p>
     The purpose of this page is to progressively list the resources useful when working on


### PR DESCRIPTION
Intro section contains typo, should be "many work groups", and not "many work group".