### PR TITLE
add details on how W3C backs up github orgs

### DIFF
--- a/backup.html
+++ b/backup.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>GitHub organizations backups</title>
+    <link rel="stylesheet" href="css/wgio.css">
+  </head>
+  <body>
+    <header>
+      <h1>GitHub organizations backups</h1>
+    </header>
+    <nav>
+      <a href="/">Home</a>
+      •
+      <a href="https://github.com/w3c/">Repositories</a>
+      •
+      <a href="https://help.github.com/">GitHub Help</a>
+    </nav>
+
+    <main>
+      <p>
+        W3C relies on <a href="https://rewind.com/">Rewind</a> to backup the different GitHub organizations the groups depend on.
+      </p>
+      <p>
+        Rewind runs daily backups of all the repositories, including metadata and provides a way to restore a repository if the GitHub support is not able to help.
+      </p>
+      <section>
+        <h3>Rewind App (GitHub)</h3>
+        <p>
+          To start the backup process for a GitHub organization, the user <a href="https://github.com/w3cbot">w3cbot</a> <em>must</em> be <a href="https://knowledge.rewind.com/s/article/which-permissions-do-i-need-to-install-rewind">listed as one of the owners of the organization</a> so it can:
+          <ul>
+            <li>install the <a href="https://github.com/apps/rewind-app-github">Rewind App</a> to the organization
+            <li>import the organization into rewind 
+            <li>restore a repository when needed
+          </ul>
+
+          After inviting w3cbot, you may request <a href="mailto:sysreq@w3.org">sysreq</a> to add your organization to rewind.
+        </p>
+      </section>
+    </main>
+    <footer>
+      <address><a href="https://github.com/w3c/w3c.github.io/">We are on GitHub</a></address>
+      <p>
+        <a href="https://www.w3.org/"><img src="img/w3c.svg" width="65" height="45" alt="W3C Logo"></a>
+      </p>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -108,6 +108,8 @@
       This is a small metadata file that is recommended for GitHub repositories under the
       <code>w3c</code> organisation.
     </dd>
+    <dt><a href="backup.html">Backup of GitHub organizations</a></dt>
+    <dd>How W3C keeps a backup of the different GitHub organizations</dd>
   </dl>
 </main>
     <footer>


### PR DESCRIPTION
That PR provides details on what's needed to start backuping a GH org with Rewind