### PR TITLE
Add robots.txt with disallow rule for wai-conformance-model-test pages

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /wai-conformance-model-test/


### PR DESCRIPTION
See https://github.com/w3c/wai-conformance-model-test/issues/1 for background.

The wai-conformance-model-test repository represents a site containing many intentional WCAG failures, including a small subset that demonstrates failures related to Guideline 2.3 (Seizures and Physical Reactions). We would really not want visitors to hit those pages directly without context.

I am opening this PR on this repository since robots.txt needs to be at the domain root level.