### PR TITLE
Redirect to /Guide/

### DIFF
--- a/documentreview/index.html
+++ b/documentreview/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/documentreview/">
+<title>Moved…</title>
+</head>
+<body onload=' location.href = "https://www.w3.org/Guide/documentreview/" + location.hash; '>
+<p>Moved to
+<a href="https://www.w3.org/Guide/documentreview/">https://www.w3.org/Guide/documentreview/</a>
+</body>

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/manual-of-style/">
+<title>Moved…</title>
+</head>
+<body onload=' location.href = "https://www.w3.org/Guide/manual-of-style/" + location.hash; '>
+<p>Moved to
+<a href="https://www.w3.org/Guide/manual-of-style/">https://www.w3.org/Guide/manual-of-style/</a>
+</body>

--- a/standards-track/index.html
+++ b/standards-track/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/documentreview/">
+<title>Moved…</title>
+</head>
+<body onload=' location.href = "https://www.w3.org/Guide/documentreview/" + location.hash; '>
+<p>Moved to
+<a href="https://www.w3.org/Guide/documentreview/">https://www.w3.org/Guide/documentreview/</a>
+</body>

--- a/standards-track/index.html
+++ b/standards-track/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/documentreview/">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/standards-track/">
 <title>Moved…</title>
 </head>
-<body onload=' location.href = "https://www.w3.org/Guide/documentreview/" + location.hash; '>
+<body onload=' location.href = "https://www.w3.org/Guide/standards-track/" + location.hash; '>
 <p>Moved to
-<a href="https://www.w3.org/Guide/documentreview/">https://www.w3.org/Guide/documentreview/</a>
+<a href="https://www.w3.org/Guide/standards-track/">https://www.w3.org/Guide/standards-track/</a>
 </body>

--- a/transitions/details.html
+++ b/transitions/details.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/transitions/details.html">
+<title>Moved…</title>
+</head>
+<body onload=' location.href = "https://www.w3.org/Guide/transitions/details.html" + location.hash; '>
+<p>Moved to
+<a href="https://www.w3.org/Guide/transitions/details.html">https://www.w3.org/Guide/transitions/details.html</a>
+</body>

--- a/transitions/index.html
+++ b/transitions/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/transitions/">
+<title>Moved…</title>
+</head>
+<body onload=' location.href = "https://www.w3.org/Guide/transitions/" + location.hash; '>
+<p>Moved to
+<a href="https://www.w3.org/Guide/transitions/">https://www.w3.org/Guide/transitions/</a>
+</body>

--- a/transitions/nextstep.html
+++ b/transitions/nextstep.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/transitions/nextstep.html">
+<title>Moved…</title>
+</head>
+<body onload=' location.href = "https://www.w3.org/Guide/transitions/nextstep.html" + location.hash; '>
+<p>Moved to
+<a href="https://www.w3.org/Guide/transitions/nextstep.html">https://www.w3.org/Guide/transitions/nextstep.html</a>
+</body>

--- a/transitions/wide-review-request.html
+++ b/transitions/wide-review-request.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://www.w3.org/Guide/transitions/wide-review-request.html">
+<title>Moved…</title>
+</head>
+<body onload=' location.href = "https://www.w3.org/Guide/transitions/wide-review-request.html" + location.hash; '>
+<p>Moved to
+<a href="https://www.w3.org/Guide/transitions/wide-review-request.html">https://www.w3.org/Guide/transitions/wide-review-request.html</a>
+</body>


### PR DESCRIPTION
The following directories have been moved to [the Guide repo](https://github.com/w3c/Guide/):
* documentreview
* manual-of-style
* standards-track
* transitions