### PR TITLE
Add redirects to APA FAST spec and checklist

### DIFF
--- a/apa/fast/checklist.html
+++ b/apa/fast/checklist.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <title>Moved…</title>
+</head>
+<body onload='location.href = "https://w3c.github.io/fast/checklist.html" + location.hash;'>
+<p>Moved to <a href="https://w3c.github.io/fast/checklist.html">https://w3c.github.io/fast/checklist.html</a>
+</body>

--- a/apa/fast/index.html
+++ b/apa/fast/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <title>Moved…</title>
+</head>
+<body onload='location.href = "https://w3c.github.io/fast/" + location.hash;'>
+<p>Moved to <a href="https://w3c.github.io/fast/">https://w3c.github.io/fast/</a>
+</body>
+


### PR DESCRIPTION
Documents were moved to a new repository some time ago, but previous URLs are used in various places, including charters, so it seems good to redirect them.

Cc @ruoxiran 